### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkBioCellularAggregate.h
+++ b/include/itkBioCellularAggregate.h
@@ -43,6 +43,8 @@ template< unsigned int NSpaceDimension = 3 >
 class ITK_TEMPLATE_EXPORT CellularAggregate:public CellularAggregateBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CellularAggregate);
+
   /** Standard class type alias. */
   using Self = CellularAggregate;
   using Superclass = CellularAggregateBase;
@@ -148,8 +150,6 @@ public:
 protected:
   CellularAggregate();
   ~CellularAggregate() override;
-  CellularAggregate(const Self &);
-  void operator=(const Self &);
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/include/itkBioCellularAggregateBase.h
+++ b/include/itkBioCellularAggregateBase.h
@@ -40,6 +40,8 @@ class ITK_FORWARD_EXPORT CellBase;
 class ITKBioCell_EXPORT CellularAggregateBase:public Object
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CellularAggregateBase);
+
   /** Standard class type alias. */
   using Self = CellularAggregateBase;
   using Superclass = Object;
@@ -67,8 +69,6 @@ public:
 protected:
   CellularAggregateBase();
   ~CellularAggregateBase() override;
-  CellularAggregateBase(const Self &);
-  void PrintSelf(std::ostream & os, Indent indent) const override;
 };
 } // end namespace bio
 } // end namespace itk


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.