### PR TITLE
ENH: Remove unnecessary, unused CMake variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(BioCell)
 
-set(BioCell_LIBRARIES BioCell)
-
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})


### PR DESCRIPTION
Remove unnecessary, unused CMake `BioCell_LIBRARIES` variable.