### PR TITLE
COMP: Change old enum to new enum class definitions

### DIFF
--- a/include/itkBioCellularAggregate.hxx
+++ b/include/itkBioCellularAggregate.hxx
@@ -36,7 +36,7 @@ CellularAggregate< NSpaceDimension >
 
   m_Mesh = MeshType::New();
 
-  m_Mesh->SetCellsAllocationMethod(MeshType::CellsAllocatedDynamicallyCellByCell);
+  m_Mesh->SetCellsAllocationMethod(MeshType::CellsAllocationMethodType::CellsAllocatedDynamicallyCellByCell);
   m_Mesh->SetPoints( PointsContainer::New() );
   m_Mesh->SetPointData( PointDataContainer::New() );
   m_Mesh->SetCells( VoronoiRegionsContainer::New() );


### PR DESCRIPTION
Changed to reference new enum class: MeshClassCellsAllocationMethodType instead of MeshType

Fixes build errors when ITK is configured with: 

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

Co-Authored-By: Hans Johnson <hans-johnson@uiowa.edu>