### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkBioCellularAggregate.h
+++ b/include/itkBioCellularAggregate.h
@@ -44,7 +44,7 @@ template <unsigned int NSpaceDimension = 3>
 class ITK_TEMPLATE_EXPORT CellularAggregate : public CellularAggregateBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CellularAggregate);
+  ITK_DISALLOW_COPY_AND_MOVE(CellularAggregate);
 
   /** Standard class type alias. */
   using Self = CellularAggregate;

--- a/include/itkBioCellularAggregateBase.h
+++ b/include/itkBioCellularAggregateBase.h
@@ -41,7 +41,7 @@ class ITK_FORWARD_EXPORT CellBase;
 class BioCell_EXPORT CellularAggregateBase : public Object
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CellularAggregateBase);
+  ITK_DISALLOW_COPY_AND_MOVE(CellularAggregateBase);
 
   /** Standard class type alias. */
   using Self = CellularAggregateBase;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.