### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkBioCell.hxx
+++ b/include/itkBioCell.hxx
@@ -19,7 +19,6 @@
 #ifndef itkBioCell_hxx
 #define itkBioCell_hxx
 
-#include "itkBioCell.h"
 #include "itkMath.h"
 #include "vnl/vnl_sample.h"
 #include <new>

--- a/include/itkBioCellularAggregate.hxx
+++ b/include/itkBioCellularAggregate.hxx
@@ -19,7 +19,6 @@
 #ifndef itkBioCellularAggregate_hxx
 #define itkBioCellularAggregate_hxx
 
-#include "itkBioCellularAggregate.h"
 
 namespace itk
 {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

