### PR TITLE
ENH: Upgrade CI for ITK 5.4.0

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,130 +1,15 @@
+
 name: Build, test, package
 
 on: [push,pull_request]
 
 jobs:
-  build-test-cxx:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 3
-      matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
-        include:
-          - os: ubuntu-18.04
-            c-compiler: "gcc"
-            cxx-compiler: "g++"
-            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
-            cmake-build-type: "MinSizeRel"
-          - os: windows-2019
-            c-compiler: "cl.exe"
-            cxx-compiler: "cl.exe"
-            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
-            cmake-build-type: "Release"
-          - os: macos-10.15
-            c-compiler: "clang"
-            cxx-compiler: "clang++"
-            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
-            cmake-build-type: "MinSizeRel"
+  cxx-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
 
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install ninja
-
-      - name: Get specific version of CMake, Ninja
-        uses: lukka/get-cmake@v3.18.3
-
-      - name: Download ITK
-        run: |
-          cd ..
-          git clone https://github.com/InsightSoftwareConsortium/ITK.git
-          cd ITK
-          git checkout ${{ matrix.itk-git-tag }}
-
-      - name: Build ITK
-        if: matrix.os != 'windows-2019'
-        run: |
-          cd ..
-          mkdir ITK-build
-          cd ITK-build
-          cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
-          ninja
-
-      - name: Build ITK
-        if: matrix.os == 'windows-2019'
-        run: |
-          cd ..
-          mkdir ITK-build
-          cd ITK-build
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
-          ninja
-        shell: cmd
-
-      - name: Fetch CTest driver script
-        run: |
-          curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
-
-      - name: Configure CTest script
-        shell: bash
-        run: |
-          operating_system="${{ matrix.os }}"
-          cat > dashboard.cmake << EOF
-          set(CTEST_SITE "GitHubActions")
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
-          file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
-          set(dashboard_source_name "${GITHUB_REPOSITORY}")
-          if(ENV{GITHUB_REF} MATCHES "master")
-            set(branch "-master")
-            set(dashboard_model "Continuous")
-          else()
-            set(branch "-${GITHUB_REF}")
-            set(dashboard_model "Experimental")
-          endif()
-          set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${operating_system}-\${branch}")
-          set(CTEST_UPDATE_VERSION_ONLY 1)
-          set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
-          set(CTEST_BUILD_CONFIGURATION "Release")
-          set(CTEST_CMAKE_GENERATOR "Ninja")
-          set(CTEST_CUSTOM_WARNING_EXCEPTION
-            \${CTEST_CUSTOM_WARNING_EXCEPTION}
-            # macOS Azure VM Warning
-            "ld: warning: text-based stub file"
-            )
-          set(dashboard_no_clean 1)
-          set(ENV{CC} ${{ matrix.c-compiler }})
-          set(ENV{CXX} ${{ matrix.cxx-compiler }})
-          if(WIN32)
-            set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
-          endif()
-          set(dashboard_cache "
-          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
-          BUILD_TESTING:BOOL=ON
-          ")
-          string(TIMESTAMP build_date "%Y-%m-%d")
-          message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
-          message("CTEST_SITE = \${CTEST_SITE}")
-          include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
-          EOF
-          cat dashboard.cmake
-
-      - name: Build and test
-        if: matrix.os != 'windows-2019'
-        run: |
-          ctest --output-on-failure -j 2 -V -S dashboard.cmake
-
-      - name: Build and test
-        if: matrix.os == 'windows-2019'
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          ctest --output-on-failure -j 2 -V -S dashboard.cmake
-        shell: cmd
+  python-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    with:
+      test-notebooks: false
+    secrets:
+      pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Upgrade CI testing to use the latest ITK 5.4.0 version and CI configuration.

Committed via https://github.com/asottile/all-repos