### PR TITLE
COMP: Update RemoteModulePackageAction and Python 3.10+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -10,6 +10,8 @@ jobs:
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
+      itk-wheel-tag: 'v5.4.5'
+      itk-python-package-tag: 'v5.4.5'
       test-notebooks: false
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,10 +5,10 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
       test-notebooks: false
     secrets:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,10 +5,10 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       test-notebooks: false
     secrets:

--- a/include/itkBioCellularAggregate.hxx
+++ b/include/itkBioCellularAggregate.hxx
@@ -606,10 +606,10 @@ CellularAggregate<NSpaceDimension>::GetSubstrateValue(IdentifierType cellId, uns
 
   typename SubstrateType::IndexType index;
 
-  substrate->TransformPhysicalPointToIndex(cellPosition, index);
+  const bool isInside = substrate->TransformPhysicalPointToIndex(cellPosition, index);
 
   SubstrateValueType value = 0;
-  if (substrate->GetBufferedRegion().IsInside(index))
+  if (isInside && substrate->GetBufferedRegion().IsInside(index))
   {
     value = substrate->GetPixel(index);
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]
@@ -47,7 +47,7 @@ Homepage = "https://github.com/InsightSoftwareConsortium/ITKBioCell"
 # The versions of CMake to allow. If CMake is not present on the system or does
 # not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
-cmake.version = ">=3.16.3"
+cmake.version = ">=3.22.1"
 
 # A list of args to pass to CMake when configuring the project. Setting this in
 # config or envvar will override toml. See also ``cmake.define``.

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,7 @@
 itk_wrap_module(BioCell)
+set(WRAPPER_SUBMODULE_ORDER
+  itkBioCellularAggregateBase
+  itkBioCellularAggregate
+)
 itk_auto_load_submodules()
 itk_end_wrap_module()

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,0 +1,3 @@
+itk_wrap_module(BioCell)
+itk_auto_load_submodules()
+itk_end_wrap_module()

--- a/wrapping/itkBioCellularAggregate.wrap
+++ b/wrapping/itkBioCellularAggregate.wrap
@@ -1,0 +1,4 @@
+itk_wrap_class("itk::bio::CellularAggregate" POINTER)
+  itk_wrap_template("2" "2")
+  itk_wrap_template("3" "3")
+itk_end_wrap_class()

--- a/wrapping/itkBioCellularAggregate.wrap
+++ b/wrapping/itkBioCellularAggregate.wrap
@@ -1,5 +1,7 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkBioCellularAggregate.h")
 itk_wrap_class("itk::bio::CellularAggregate" POINTER)
   itk_wrap_template("2" "2")
   itk_wrap_template("3" "3")
 itk_end_wrap_class()
+set(WRAPPER_AUTO_INCLUDE_HEADERS ON)

--- a/wrapping/itkBioCellularAggregate.wrap
+++ b/wrapping/itkBioCellularAggregate.wrap
@@ -1,3 +1,4 @@
+itk_wrap_include("itkBioCellularAggregate.h")
 itk_wrap_class("itk::bio::CellularAggregate" POINTER)
   itk_wrap_template("2" "2")
   itk_wrap_template("3" "3")

--- a/wrapping/itkBioCellularAggregateBase.wrap
+++ b/wrapping/itkBioCellularAggregateBase.wrap
@@ -1,2 +1,3 @@
+itk_wrap_include("itkBioCellularAggregateBase.h")
 itk_wrap_class("itk::bio::CellularAggregateBase" POINTER)
 itk_end_wrap_class()

--- a/wrapping/itkBioCellularAggregateBase.wrap
+++ b/wrapping/itkBioCellularAggregateBase.wrap
@@ -1,0 +1,2 @@
+itk_wrap_class("itk::bio::CellularAggregateBase" POINTER)
+itk_end_wrap_class()

--- a/wrapping/itkBioCellularAggregateBase.wrap
+++ b/wrapping/itkBioCellularAggregateBase.wrap
@@ -1,3 +1,4 @@
+set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_include("itkBioCellularAggregateBase.h")
-itk_wrap_class("itk::bio::CellularAggregateBase" POINTER)
-itk_end_wrap_class()
+itk_wrap_simple_class("itk::bio::CellularAggregateBase" POINTER)
+set(WRAPPER_AUTO_INCLUDE_HEADERS ON)


### PR DESCRIPTION
Update github actions to v5.4.5 and package management for python 3.10+

- Bump workflow action from v5.4.0 to v5.4.5 to use the v5.4.5 ITKPythonBuilds release
- Update minimum Python version from 3.8 to 3.10
- Add Python wrapping for CellularAggregateBase and CellularAggregate
- Fix wrapping for itk::bio namespace classes (WRAPPER_AUTO_INCLUDE_HEADERS, itk_wrap_simple_class, WRAPPER_SUBMODULE_ORDER)